### PR TITLE
Correcting Typo's  in SQLServerLTS-SystemsManager-AutomationAdministr…

### DIFF
--- a/organization/CloudFormation/template.yaml
+++ b/organization/CloudFormation/template.yaml
@@ -405,7 +405,7 @@ Resources:
                   "TargetLocations": [
                     {
                       "Accounts": "{{ DeploymentTargets }}",
-                      "ExecutionRoleName": "SQLServerLTS-SystemsManagerAutomationExecutionRole",
+                      "ExecutionRoleName": "SQLServerLTS-SystemsManager-AutomationExecutionRole",
                       "Regions": "{{ TargetRegions }}",
                       "TargetLocationMaxConcurrency": "{{ MaxConcurrency }}",
                       "TargetLocationMaxErrors": "{{ MaxErrors }}"
@@ -430,7 +430,7 @@ Resources:
                   "TargetLocations": [
                     {
                       "Accounts": "{{ DeploymentTargets }}",
-                      "ExecutionRoleName": "SQLServerLTS-SystemsManagerAutomationExecutionRole",
+                      "ExecutionRoleName": "SQLServerLTS-SystemsManager-AutomationExecutionRole",
                       "Regions": "{{ TargetRegions }}",
                       "TargetLocationMaxConcurrency": "{{ MaxConcurrency }}",
                       "TargetLocationMaxErrors": "{{ MaxErrors }}"


### PR DESCRIPTION
…ationRole

SQLServerLTS-SystemsManager-AutomationAdministrationRole,  There were a few locations that did not have the - in the role name.  so when doing the association from the main org account it was not able to find the correctly named role in an executing account

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
